### PR TITLE
Add condition for No ManagedClusterSetBindings

### DIFF
--- a/pkg/controllers/scheduling/scheduling_controller.go
+++ b/pkg/controllers/scheduling/scheduling_controller.go
@@ -175,6 +175,9 @@ func (c *schedulingController) sync(ctx context.Context, syncCtx factory.SyncCon
 	}
 
 	// update placement status if necessary
+	if clusters == nil {
+		scheduleResult.unscheduled = -1
+	}
 	return c.updateStatus(ctx, placement, scheduleResult.scheduled, scheduleResult.unscheduled)
 }
 
@@ -248,6 +251,10 @@ func newSatisfiedCondition(numOfUnscheduledDecisions int) metav1.Condition {
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = "AllDecisionsScheduled"
 		condition.Message = "All cluster decisions scheduled"
+	case numOfUnscheduledDecisions == -1:
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = "NoManagedClusterSetBindings"
+		condition.Message = "No ManagedClusterSetBindings found in placement namespace"
 	default:
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = "NotAllDecisionsScheduled"

--- a/pkg/controllers/scheduling/scheduling_controller.go
+++ b/pkg/controllers/scheduling/scheduling_controller.go
@@ -2,14 +2,13 @@ package scheduling
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -158,7 +157,7 @@ func (c *schedulingController) sync(ctx context.Context, syncCtx factory.SyncCon
 
 	klog.V(4).Infof("Reconciling placement %q", queueKey)
 	placement, err := c.placementLister.Placements(namespace).Get(name)
-	if k8serrors.IsNotFound(err) {
+	if errors.IsNotFound(err) {
 		// no work if placement is deleted
 		return nil
 	}
@@ -202,7 +201,7 @@ func (c *schedulingController) getAvailableClusters(placement *clusterapiv1alpha
 		return nil, err
 	}
 	if len(bindings) == 0 {
-		return nil, errors.New("No ManagedClusterSetBindings available")
+		return nil, fmt.Errorf("No ManagedClusterSetBindings available")
 	}
 
 	// filter out invaid clustersetbindings
@@ -210,7 +209,7 @@ func (c *schedulingController) getAvailableClusters(placement *clusterapiv1alpha
 	for _, binding := range bindings {
 		// ignore clusterset does not exist
 		_, err := c.clusterSetLister.Get(binding.Name)
-		if k8serrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			continue
 		}
 		if err != nil {

--- a/pkg/controllers/scheduling/scheduling_controller_test.go
+++ b/pkg/controllers/scheduling/scheduling_controller_test.go
@@ -60,6 +60,11 @@ func TestSchedulingController_sync(t *testing.T) {
 		{
 			name:      "placement unsatisfied",
 			placement: testinghelpers.NewPlacement(placementNamespace, placementName).Build(),
+			initObjs: []runtime.Object{
+				testinghelpers.NewClusterSet("clusterset1"),
+				testinghelpers.NewClusterSetBinding(placementNamespace, "clusterset1"),
+				testinghelpers.NewManagedCluster("cluster1").WithLabel(clusterSetLabel, "clusterset1").Build(),
+			},
 			scheduleResult: &scheduleResult{
 				scheduled:   3,
 				unscheduled: 1,

--- a/pkg/controllers/scheduling/scheduling_controller_test.go
+++ b/pkg/controllers/scheduling/scheduling_controller_test.go
@@ -228,7 +228,12 @@ func TestGetAvailableClusters(t *testing.T) {
 				clusterSetLister:        clusterInformerFactory.Cluster().V1alpha1().ManagedClusterSets().Lister(),
 				clusterSetBindingLister: clusterInformerFactory.Cluster().V1alpha1().ManagedClusterSetBindings().Lister(),
 			}
-			clusters, err := ctrl.getAvailableClusters(c.placement)
+			bindings, err := ctrl.getManagedClusterSetBindings(c.placement)
+			if err != nil {
+				t.Errorf("unexpected err: %v", err)
+			}
+
+			clusters, err := ctrl.getAvailableClusters(c.placement, bindings)
 			if err != nil {
 				t.Errorf("unexpected err: %v", err)
 			}

--- a/pkg/controllers/scheduling/scheduling_controller_test.go
+++ b/pkg/controllers/scheduling/scheduling_controller_test.go
@@ -95,7 +95,7 @@ func TestSchedulingController_sync(t *testing.T) {
 			placement: testinghelpers.NewPlacement(placementNamespace, placementName).Build(),
 			scheduleResult: &scheduleResult{
 				scheduled:   0,
-				unscheduled: -1,
+				unscheduled: 0,
 			},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
 				// check if PlacementDecision has been updated


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Add a specific condition that reports that no ManagedClusterSetBindings were found to alert the user that they will need to create a binding before placement will be able to resolve.